### PR TITLE
Add pulsar dataset and page

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository hosts a static website for browsing Fast Radio Burst (FRB) data.
 - **index.html** - overview table of all FRB detections.
 - **repeaters.html** - table of repeating FRB sources.
 - **plots.html** - basic chart visualisation of catalogue entries.
+- **pulsars.html** - table of pulsars with chart.
 
 ## Local Testing..
 

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <header>
-    <nav><a href="index.html">Home</a> | <a href="repeaters.html">Repeaters</a> | <a href="plots.html">Plots</a></nav>
+    <nav><a href="index.html">Home</a> | <a href="repeaters.html">Repeaters</a> | <a href="plots.html">Plots</a> | <a href="pulsars.html">Pulsars</a></nav>
     <h1>FRBExplorer</h1>
   </header>
   <main>

--- a/js/pulsars.js
+++ b/js/pulsars.js
@@ -1,0 +1,58 @@
+fetch('pulsars.json')
+  .then(response => response.json())
+  .then(data => {
+    const table = document.getElementById('pulsar-table');
+    if (!data.length) {
+      document.getElementById('status').textContent = 'No data available';
+      return;
+    }
+    document.getElementById('status').remove();
+    const headers = Object.keys(data[0]);
+    const thead = document.createElement('thead');
+    const headerRow = document.createElement('tr');
+    headers.forEach(h => {
+      const th = document.createElement('th');
+      th.textContent = h;
+      headerRow.appendChild(th);
+    });
+    thead.appendChild(headerRow);
+    table.appendChild(thead);
+    const tbody = document.createElement('tbody');
+    data.forEach(row => {
+      const tr = document.createElement('tr');
+      headers.forEach(h => {
+        const td = document.createElement('td');
+        td.textContent = row[h];
+        tr.appendChild(td);
+      });
+      tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+
+    // Chart
+    const ctx = document.getElementById('pulsar-chart').getContext('2d');
+    new Chart(ctx, {
+      type: 'scatter',
+      data: {
+        datasets: [{
+          label: 'Period vs SNR',
+          data: data.map(d => ({ x: d.period, y: d.snr })),
+          backgroundColor: 'rgba(255, 99, 132, 0.5)'
+        })
+      },
+      options: {
+        scales: {
+          x: {
+            title: { display: true, text: 'Period (s)' }
+          },
+          y: {
+            title: { display: true, text: 'SNR' }
+          }
+        }
+      }
+    });
+  })
+  .catch(err => {
+    console.error('Error loading data', err);
+    document.getElementById('status').textContent = 'Failed to load data';
+  });

--- a/plots.html
+++ b/plots.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <header>
-    <nav><a href="index.html">Home</a> | <a href="repeaters.html">Repeaters</a> | <a href="plots.html">Plots</a></nav>
+    <nav><a href="index.html">Home</a> | <a href="repeaters.html">Repeaters</a> | <a href="plots.html">Plots</a> | <a href="pulsars.html">Pulsars</a></nav>
     <h1>FRB Plots</h1>
   </header>
   <main>

--- a/pulsars.html
+++ b/pulsars.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>FRBExplorer - Pulsars</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <header>
+    <nav><a href="index.html">Home</a> | <a href="repeaters.html">Repeaters</a> | <a href="plots.html">Plots</a> | <a href="pulsars.html">Pulsars</a></nav>
+    <h1>Pulsars</h1>
+  </header>
+  <main>
+    <section>
+      <p>Pulsars are fast-rotating neutron stars emitting beams of electromagnetic radiation, observed as regular pulses—like a cosmic lighthouse. Their properties such as pulse period, signal-to-noise ratio (SNR), and rotation speed provide insight into extreme physics including gravity and magnetism.</p>
+    </section>
+    <p id="status">Loading pulsars...</p>
+    <table id="pulsar-table"></table>
+    <canvas id="pulsar-chart" width="400" height="300"></canvas>
+  </main>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="js/pulsars.js"></script>
+</body>
+</html>

--- a/pulsars.json
+++ b/pulsars.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "PSR J0534+2200",
+    "ra": 83.6331,
+    "dec": 22.0145,
+    "period": 0.0331,
+    "snr": 1000,
+    "magnetic_field": 3.8e12,
+    "discovery_year": 1967
+  },
+  {
+    "name": "PSR J0835-4510",
+    "ra": 128.835,
+    "dec": -45.175,
+    "period": 0.0893,
+    "snr": 850,
+    "magnetic_field": 3.4e12,
+    "discovery_year": 1968
+  }
+]

--- a/repeaters.html
+++ b/repeaters.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <header>
-    <nav><a href="index.html">Home</a> | <a href="repeaters.html">Repeaters</a> | <a href="plots.html">Plots</a></nav>
+    <nav><a href="index.html">Home</a> | <a href="repeaters.html">Repeaters</a> | <a href="plots.html">Plots</a> | <a href="pulsars.html">Pulsars</a></nav>
     <h1>Repeating FRBs</h1>
   </header>
   <main>


### PR DESCRIPTION
## Summary
- list pulsars.html in README
- link to Pulsars page from all navigation menus
- add pulsars data file
- add Pulsars page and loader script

## Testing
- `python3 -m py_compile $(find . -name '*.py' 2>/dev/null)` *(fails: no files specified)*

------
https://chatgpt.com/codex/tasks/task_e_686290ef9a048324918e15e8870135b3