### PR TITLE
Fix pulsar fetch and add update scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,7 @@ Then open `http://localhost:8000/index.html` in your browser. You can navigate t
 
 ## Pulsar Data
 
-Run `node scripts/updatePulsars.js` to fetch the latest discoveries from the ATNF pulsar catalogue and populate `pulsars.json`. The file is kept empty in the repository.
+Run `node scripts/updatePulsars.js` to fetch the latest discoveries from the ATNF pulsar catalogue and populate `pulsars.json`.
+Run `node scripts/updateCatalogue.js` to download the current FRB catalogue and write `catalogue.json`.
+Run `node scripts/updateRepeaters.js` to update `repeaters.json` with the latest repeating sources.
+All three JSON files are kept empty in the repository and generated when these scripts are executed.

--- a/scripts/updateCatalogue.js
+++ b/scripts/updateCatalogue.js
@@ -1,0 +1,34 @@
+const https = require('https');
+const fs = require('fs');
+
+const url = 'https://chime-frb-open-data.github.io/catalog.json';
+
+function fetchJSON(cb) {
+  https.get(url, { family: 4 }, res => {
+    if (res.statusCode !== 200) {
+      cb(new Error('Failed to fetch data: ' + res.statusCode));
+      return;
+    }
+    let data = '';
+    res.on('data', chunk => data += chunk);
+    res.on('end', () => cb(null, data));
+  }).on('error', err => cb(err));
+}
+
+function updateCatalogue() {
+  fetchJSON((err, text) => {
+    if (err) {
+      console.error(err.message);
+      return;
+    }
+    try {
+      const json = JSON.parse(text);
+      fs.writeFileSync('catalogue.json', JSON.stringify(json, null, 2));
+      console.log('Updated catalogue.json with', json.length, 'entries');
+    } catch (e) {
+      console.error('Failed to parse catalogue JSON');
+    }
+  });
+}
+
+updateCatalogue();

--- a/scripts/updatePulsars.js
+++ b/scripts/updatePulsars.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const url = 'https://www.atnf.csiro.au/research/pulsar/psrcat/psrcat_csv.php?delimiter=,';
 
 function fetchCatalogue(cb) {
-  https.get(url, res => {
+  https.get(url, { family: 4 }, res => {
     if (res.statusCode !== 200) {
       cb(new Error('Failed to fetch data: ' + res.statusCode));
       return;

--- a/scripts/updateRepeaters.js
+++ b/scripts/updateRepeaters.js
@@ -1,0 +1,34 @@
+const https = require('https');
+const fs = require('fs');
+
+const url = 'https://chime-frb-open-data.github.io/repeaters.json';
+
+function fetchJSON(cb) {
+  https.get(url, { family: 4 }, res => {
+    if (res.statusCode !== 200) {
+      cb(new Error('Failed to fetch data: ' + res.statusCode));
+      return;
+    }
+    let data = '';
+    res.on('data', chunk => data += chunk);
+    res.on('end', () => cb(null, data));
+  }).on('error', err => cb(err));
+}
+
+function updateRepeaters() {
+  fetchJSON((err, text) => {
+    if (err) {
+      console.error(err.message);
+      return;
+    }
+    try {
+      const json = JSON.parse(text);
+      fs.writeFileSync('repeaters.json', JSON.stringify(json, null, 2));
+      console.log('Updated repeaters.json with', json.length, 'entries');
+    } catch (e) {
+      console.error('Failed to parse repeater JSON');
+    }
+  });
+}
+
+updateRepeaters();


### PR DESCRIPTION
## Summary
- add IPv4 option in `updatePulsars.js` to avoid ENETUNREACH errors
- add `updateCatalogue.js` and `updateRepeaters.js` for automated data fetch
- document running these scripts in README

## Testing
- `node scripts/updatePulsars.js` *(fails: connect ENETUNREACH)*
- `node scripts/updateCatalogue.js` *(fails: connect ENETUNREACH)*
- `node scripts/updateRepeaters.js` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68629b5eaab08324ac9a95bbccf954be