### PR TITLE
Configure GH Pages and auto update

### DIFF
--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -1,32 +1,50 @@
-name: 🚀 Deploy website on push
+name: Deploy to GitHub Pages
 
 on:
   push:
     branches: ["main"]
-  pull_request:
-    branches: ["main"]
+  schedule:
+    - cron: '0 * * * *'
   workflow_dispatch:
 
 permissions:
   contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
 
 jobs:
-  web-deploy:
-    name: 🎉 Deploy
+  build:
     runs-on: ubuntu-latest
     steps:
-    - name: 🚚 Get latest code
-      uses: actions/checkout@v4
-    
-    - name: 📂 Sync files
-      uses: SamKirkland/FTP-Deploy-Action@v4.3.5
-      with:
-        server: ${{ secrets.FTP_SERVER }}
-        username: ${{ secrets.FTP_USERNAME }}
-        password: ${{ secrets.FTP_PASSWORD }}
-        local-dir: "./"
-        server-dir: "frbexplorer/"
-        exclude: |
-          **/.git*
-          **/.git*/**
-          **/node_modules/**
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Update data files
+        run: |
+          ./scripts/updateAll.sh
+      - name: Commit updated data
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          if ! git diff --quiet catalogue.json repeaters.json pulsars.json; then
+            git add catalogue.json repeaters.json pulsars.json
+            git commit -m "Automated data update"
+            git push
+          fi
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: './'
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v2
+        id: deployment

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository hosts a static website for browsing Fast Radio Burst (FRB) data.
 - **plots.html** - basic chart visualisation of catalogue entries.
 - **pulsars.html** - table of pulsars with chart.
 
-## Local Testing..
+## Local Testing
 
 Run a simple HTTP server in the repository root:
 
@@ -19,6 +19,14 @@ python3 -m http.server
 
 Then open `http://localhost:8000/index.html` in your browser. You can navigate to the other pages from there.
 
-## Pulsar Data
+## Automated Data Updates
 
-Run `node scripts/updatePulsars.js` to fetch the latest discoveries from the ATNF pulsar catalogue and populate `pulsars.json`. The file is kept empty in the repository.
+The repository includes a GitHub Actions workflow that fetches the latest catalogue, repeater and pulsar data once every hour and on each push. The workflow runs the helper scripts in `scripts/` and commits any changes before deploying the site to GitHub Pages.
+
+To run the update scripts locally:
+
+```bash
+./scripts/updateAll.sh
+```
+
+This will regenerate `catalogue.json`, `repeaters.json` and `pulsars.json` using the remote data sources.

--- a/scripts/updateAll.sh
+++ b/scripts/updateAll.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+node scripts/updateCatalogue.js
+node scripts/updateRepeaters.js
+node scripts/updatePulsars.js

--- a/scripts/updateCatalogue.js
+++ b/scripts/updateCatalogue.js
@@ -1,0 +1,25 @@
+const https = require('https');
+const fs = require('fs');
+
+const url = process.env.CATALOGUE_URL || 'https://chime-frb-open-data.github.io/catalog/v1/catalog.json';
+
+https.get(url, res => {
+  if (res.statusCode !== 200) {
+    console.error('Failed to fetch data: ' + res.statusCode);
+    res.resume();
+    return;
+  }
+  let data = '';
+  res.on('data', chunk => data += chunk);
+  res.on('end', () => {
+    try {
+      const json = JSON.parse(data);
+      fs.writeFileSync('catalogue.json', JSON.stringify(json, null, 2));
+      console.log('Updated catalogue.json with', json.length, 'entries');
+    } catch (err) {
+      console.error('Error parsing catalogue:', err.message);
+    }
+  });
+}).on('error', err => {
+  console.error('Request failed:', err.message);
+});

--- a/scripts/updateRepeaters.js
+++ b/scripts/updateRepeaters.js
@@ -1,0 +1,25 @@
+const https = require('https');
+const fs = require('fs');
+
+const url = process.env.REPEATERS_URL || 'https://chime-frb-open-data.github.io/catalog/v1/repeaters.json';
+
+https.get(url, res => {
+  if (res.statusCode !== 200) {
+    console.error('Failed to fetch data: ' + res.statusCode);
+    res.resume();
+    return;
+  }
+  let data = '';
+  res.on('data', chunk => data += chunk);
+  res.on('end', () => {
+    try {
+      const json = JSON.parse(data);
+      fs.writeFileSync('repeaters.json', JSON.stringify(json, null, 2));
+      console.log('Updated repeaters.json with', json.length, 'entries');
+    } catch (err) {
+      console.error('Error parsing repeaters:', err.message);
+    }
+  });
+}).on('error', err => {
+  console.error('Request failed:', err.message);
+});


### PR DESCRIPTION
## Summary
- add scripts to fetch catalogue and repeater data
- include helper script to update all JSON files
- use GitHub Actions to update data hourly and on push
- deploy the site via GitHub Pages
- document the automation in the README

## Testing
- `node scripts/updatePulsars.js` *(fails: connect ENETUNREACH)*
- `./scripts/updateAll.sh` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6862b9048458832485b9d93c9ce9e572