### PR TITLE
Fix artifact action deprecation

### DIFF
--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -36,7 +36,7 @@ jobs:
             git commit -m "Automated data update"
             git push
           fi
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: './'
   deploy:
@@ -46,5 +46,5 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/deploy-pages@v2
+      - uses: actions/deploy-pages@v4
         id: deployment


### PR DESCRIPTION
## Summary
- upgrade GitHub Pages actions to newer versions so the workflow uses `upload-artifact@v4`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862c26fa2ac8324a0bc4f75296c56c3